### PR TITLE
Fix Crash when a Customization TextField is empty

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/gui/AdvancedTerrainShapeTab.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/gui/AdvancedTerrainShapeTab.java
@@ -466,24 +466,24 @@ class AdvancedTerrainShapeTab {
 		 * - If they happen, turn the Cursor to red, as soon as a value is valid, turn back to default grey.
 		 * - If the customization is left (by pressing Done) when such an error exists, the value resets to default.
 		 */
-		try{
+		try {
 			conf.expectedBaseHeight = Float.parseFloat(this.expectedBaseHeight.getText());
 			this.expectedBaseHeight.setCursorColor(0xD0D0D0);
-		}catch(NumberFormatException e){
+		} catch (NumberFormatException e) {
 			this.expectedBaseHeight.setCursorColor(0xD00000);
 		}
 		
-		try{
+		try {
 			conf.expectedHeightVariation = Float.parseFloat(this.expectedHeightVariation.getText());
 			this.expectedHeightVariation.setCursorColor(0xD0D0D0);
-		}catch(NumberFormatException e){
+		} catch (NumberFormatException e) {
 			this.expectedHeightVariation.setCursorColor(0xD00000);
 		}
 		
-		try{
+		try {
 			conf.actualHeight = Float.parseFloat(this.actualHeight.getText());
 			this.actualHeight.setCursorColor(0xD0D0D0);
-		}catch(NumberFormatException e){
+		} catch (NumberFormatException e) {
 			this.actualHeight.setCursorColor(0xD00000);
 		}
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/gui/AdvancedTerrainShapeTab.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/gui/AdvancedTerrainShapeTab.java
@@ -461,9 +461,31 @@ class AdvancedTerrainShapeTab {
     }
 
     void writeConfig(CustomGeneratorSettings conf) {
-        conf.expectedBaseHeight = Float.parseFloat(this.expectedBaseHeight.getText());
-        conf.expectedHeightVariation = Float.parseFloat(this.expectedHeightVariation.getText());
-        conf.actualHeight = Float.parseFloat(this.actualHeight.getText());
+		/* 
+		 * Possible NumberFormatException errors in TextFields. 
+		 * - If they happen, turn the Cursor to red, as soon as a value is valid, turn back to default grey.
+		 * - If the customization is left (by pressing Done) when such an error exists, the value resets to default.
+		 */
+		try{
+			conf.expectedBaseHeight = Float.parseFloat(this.expectedBaseHeight.getText());
+			this.expectedBaseHeight.setCursorColor(0xD0D0D0);
+		}catch(NumberFormatException e){
+			this.expectedBaseHeight.setCursorColor(0xD00000);
+		}
+		
+		try{
+			conf.expectedHeightVariation = Float.parseFloat(this.expectedHeightVariation.getText());
+			this.expectedHeightVariation.setCursorColor(0xD0D0D0);
+		}catch(NumberFormatException e){
+			this.expectedHeightVariation.setCursorColor(0xD00000);
+		}
+		
+		try{
+			conf.actualHeight = Float.parseFloat(this.actualHeight.getText());
+			this.actualHeight.setCursorColor(0xD0D0D0);
+		}catch(NumberFormatException e){
+			this.actualHeight.setCursorColor(0xD00000);
+		}
 
         conf.heightVariationFactor = this.heightVariationFactor.getValue();
         conf.specialHeightVariationFactorBelowAverageY = this.heightVariationSpecialFactor.getValue();

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/gui/AdvancedTerrainShapeTab.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/gui/AdvancedTerrainShapeTab.java
@@ -461,31 +461,31 @@ class AdvancedTerrainShapeTab {
     }
 
     void writeConfig(CustomGeneratorSettings conf) {
-		/* 
-		 * Possible NumberFormatException errors in TextFields. 
-		 * - If they happen, turn the Cursor to red, as soon as a value is valid, turn back to default grey.
-		 * - If the customization is left (by pressing Done) when such an error exists, the value resets to default.
-		 */
-		try {
-			conf.expectedBaseHeight = Float.parseFloat(this.expectedBaseHeight.getText());
-			this.expectedBaseHeight.setCursorColor(0xD0D0D0);
-		} catch (NumberFormatException e) {
-			this.expectedBaseHeight.setCursorColor(0xD00000);
-		}
-		
-		try {
-			conf.expectedHeightVariation = Float.parseFloat(this.expectedHeightVariation.getText());
-			this.expectedHeightVariation.setCursorColor(0xD0D0D0);
-		} catch (NumberFormatException e) {
-			this.expectedHeightVariation.setCursorColor(0xD00000);
-		}
-		
-		try {
-			conf.actualHeight = Float.parseFloat(this.actualHeight.getText());
-			this.actualHeight.setCursorColor(0xD0D0D0);
-		} catch (NumberFormatException e) {
-			this.actualHeight.setCursorColor(0xD00000);
-		}
+        /* 
+         * Possible NumberFormatException errors in TextFields. 
+         * - If they happen, turn the Cursor to red, as soon as a value is valid, turn back to default grey.
+         * - If the customization is left (by pressing Done) when such an error exists, the value resets to default.
+         */
+        try {
+            conf.expectedBaseHeight = Float.parseFloat(this.expectedBaseHeight.getText());
+            this.expectedBaseHeight.setCursorColor(0xD0D0D0);
+        } catch (NumberFormatException e) {
+            this.expectedBaseHeight.setCursorColor(0xD00000);
+        }
+        
+        try {
+            conf.expectedHeightVariation = Float.parseFloat(this.expectedHeightVariation.getText());
+            this.expectedHeightVariation.setCursorColor(0xD0D0D0);
+        } catch (NumberFormatException e) {
+            this.expectedHeightVariation.setCursorColor(0xD00000);
+        }
+        
+        try {
+            conf.actualHeight = Float.parseFloat(this.actualHeight.getText());
+            this.actualHeight.setCursorColor(0xD0D0D0);
+        } catch (NumberFormatException e) {
+            this.actualHeight.setCursorColor(0xD00000);
+        }
 
         conf.heightVariationFactor = this.heightVariationFactor.getValue();
         conf.specialHeightVariationFactorBelowAverageY = this.heightVariationSpecialFactor.getValue();


### PR DESCRIPTION
The empty string caused the  String parsing for the textfields
- expectedBaseHeight
- expectedHeightVariation
- actualHeight

to fail with a NumberFormatException, resulting in a crash.
This fix catches that exception, turns the cursor in the field red (and as soon as a proper value is detected back to grey) and if the menu is left (by clicking Done) with an empty field, that field resets to default.