### PR TITLE
Fix DerivedWorldInfo to overwrite generator settings with defaults

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/asm/mixin/common/MixinSaveHandler.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/asm/mixin/common/MixinSaveHandler.java
@@ -33,6 +33,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import io.github.opencubicchunks.cubicchunks.cubicgen.common.world.storage.IWorldInfoAccess;
 import io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.CustomGeneratorSettings;
+import io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.CustomGeneratorSettingsFixer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.storage.ISaveHandler;
 import net.minecraft.world.storage.SaveHandler;
@@ -48,10 +49,15 @@ public class MixinSaveHandler {
         String generatorOptions = CustomGeneratorSettings.loadJsonStringFromSaveFolder((ISaveHandler) (Object) this);
         if (generatorOptions == null)
             return;
+        boolean isOutdated = !CustomGeneratorSettingsFixer.isUpToDate(generatorOptions);
+        if (isOutdated) {
+            generatorOptions = CustomGeneratorSettingsFixer.fixGeneratorOptions(generatorOptions, null);
+            CustomGeneratorSettings.saveToFile((ISaveHandler) (Object) this, generatorOptions);
+        }
         IWorldInfoAccess worldInfo = (IWorldInfoAccess) cir.getReturnValue();
         worldInfo.setGeneratorOptions(generatorOptions);
     }
-    
+
     @Inject(method = "saveWorldInfoWithPlayer", at = @At("RETURN"))
     public void onSavingWorldInfoWithPlayer(WorldInfo worldInformation, @Nullable NBTTagCompound tagCompound,
             CallbackInfo ci) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/CustomGeneratorSettings.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/CustomGeneratorSettings.java
@@ -42,6 +42,7 @@ import io.github.opencubicchunks.cubicchunks.api.world.ICube;
 import io.github.opencubicchunks.cubicchunks.cubicgen.ConversionUtils;
 import io.github.opencubicchunks.cubicchunks.cubicgen.CustomCubicMod;
 import io.github.opencubicchunks.cubicchunks.cubicgen.common.biome.BiomeBlockReplacerConfig;
+import io.github.opencubicchunks.cubicchunks.cubicgen.common.world.storage.IWorldInfoAccess;
 import net.minecraft.block.BlockSilverfish;
 import net.minecraft.block.BlockStone;
 import net.minecraft.block.state.IBlockState;
@@ -232,17 +233,18 @@ public class CustomGeneratorSettings {
         CustomGeneratorSettings settings;
         if (jsonString.isEmpty()) {
             settings = defaults();
-            settings.save(world);
+            IWorldInfoAccess wia = (IWorldInfoAccess) world.getWorldInfo();
+            wia.setGeneratorOptions(settings.toJson());
             return settings;
         }
         boolean isOutdated = !CustomGeneratorSettingsFixer.isUpToDate(jsonString);
         if (isOutdated) {
             jsonString = CustomGeneratorSettingsFixer.fixGeneratorOptions(jsonString, null);
+            IWorldInfoAccess wia = (IWorldInfoAccess) world.getWorldInfo();
+            wia.setGeneratorOptions(jsonString);
         }
         Gson gson = gson();
         settings = gson.fromJson(jsonString, CustomGeneratorSettings.class);
-        if (isOutdated || !getPresetFile(world.getSaveHandler()).exists())
-            settings.save(world);
         return settings;
     }
     


### PR DESCRIPTION
WorldServerMulti class has a custom implementation of WorldInfo which called DerivedWorldInfo. While those world instances loaded they request biome provider which request CustomGeneratorSettings. After settings detect that generator options string is empty they overwrite file with defaults. 
Example with FlansMod installed:
```[11:42:27] [Server thread/INFO] [FML]: Loading dimension 1 (New World--) (net.minecraft.server.integrated.IntegratedServer@20d4cca9)
[11:42:27] [Server thread/INFO] [cubicchunks]: Initializing world net.minecraft.world.WorldServerMulti@37e8e1de with type io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.CustomCubicWorldType@2c56a486
[11:42:27] [Server thread/ERROR] [cubicgen]: Cannot create new directory at /home/foghrye4/.minecraft/saves/New World--/data/cubicgen
[11:42:27] [Server thread/ERROR] [cubicgen]: Catching
java.io.FileNotFoundException: /home/foghrye4/.minecraft/saves/New World--/data/cubicgen/custom_generator_settings.json (Permission denied)
	at java.io.FileOutputStream.open0(Native Method) ~[?:1.8.0_111]
	at java.io.FileOutputStream.open(FileOutputStream.java:270) ~[?:1.8.0_111]
	at java.io.FileOutputStream.<init>(FileOutputStream.java:213) ~[?:1.8.0_111]
	at java.io.FileOutputStream.<init>(FileOutputStream.java:162) ~[?:1.8.0_111]
	at java.io.FileWriter.<init>(FileWriter.java:90) ~[?:1.8.0_111]
	at io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.CustomGeneratorSettings.saveToFile(CustomGeneratorSettings.java:257) [CustomGeneratorSettings.class:?]
	at io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.CustomGeneratorSettings.save(CustomGeneratorSettings.java:250) [CustomGeneratorSettings.class:?]
	at io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.CustomGeneratorSettings.load(CustomGeneratorSettings.java:235) [CustomGeneratorSettings.class:?]
	at io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.CustomCubicWorldType.getBiomeProvider(CustomCubicWorldType.java:82) [CustomCubicWorldType.class:?]
	at net.minecraft.world.WorldProvider.func_76572_b(WorldProvider.java:58) [aym.class:?]
	at com.flansmod.apocalypse.common.world.WorldProviderApocalypse.func_76572_b(WorldProviderApocalypse.java:23) [WorldProviderApocalypse.class:?]
	at net.minecraft.world.WorldProvider.func_76558_a(WorldProvider.java:40) [aym.class:?]
	at net.minecraft.world.WorldServer.<init>(WorldServer.java:116) [oo.class:?]
	at net.minecraft.world.WorldServerMulti.<init>(WorldServerMulti.java:18) [ok.class:?]
	at net.minecraft.server.integrated.IntegratedServer.func_71247_a(IntegratedServer.java:126) [chd.class:?]
	at net.minecraft.server.integrated.IntegratedServer.func_71197_b(IntegratedServer.java:156) [chd.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:486) [MinecraftServer.class:?]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_111]
[11:42:27] [Server thread/INFO] [FML]: Loading dimension 2 (New World--) (net.minecraft.server.integrated.IntegratedServer@20d4cca9)
```
This PR is fixing issue.