### PR TITLE
Allow to create CustomTerrainGenerator instance with custom biome pro…

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/CustomTerrainGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/CustomTerrainGenerator.java
@@ -95,14 +95,14 @@ public class CustomTerrainGenerator extends BasicCubeGenerator {
     @Nonnull private CubicFeatureGenerator strongholds;
 
     public CustomTerrainGenerator(World world, final long seed) {
-        this(world, CustomGeneratorSettings.load(world), seed);
+        this(world, world.getBiomeProvider(), CustomGeneratorSettings.load(world), seed);
     }
 
-    public CustomTerrainGenerator(World world, CustomGeneratorSettings settings, final long seed) {
-        this(world, settings, seed, true);
+    public CustomTerrainGenerator(World world, BiomeProvider biomeProvider, CustomGeneratorSettings settings, final long seed) {
+        this(world, biomeProvider, settings, seed, true);
     }
 
-    private CustomTerrainGenerator(World world, CustomGeneratorSettings settings, final long seed, boolean isMainLayer) {
+    private CustomTerrainGenerator(World world, BiomeProvider biomeProvider, CustomGeneratorSettings settings, final long seed, boolean isMainLayer) {
         super(world);
         this.conf = settings;
 
@@ -115,13 +115,12 @@ public class CustomTerrainGenerator extends BasicCubeGenerator {
         this.ravineGenerator = new CubicRavineGenerator(conf);
 
         this.fillCubeBiomes = !isMainLayer;
-        BiomeProvider biomes = isMainLayer ? world.getBiomeProvider() : CustomCubicWorldType.makeBiomeProvider(world, settings);
-        this.biomeSource = new BiomeSource(world, conf.createBiomeBlockReplacerConfig(), biomes, 2);
+        this.biomeSource = new BiomeSource(world, conf.createBiomeBlockReplacerConfig(), biomeProvider, 2);
         initGenerator(seed);
 
         if (settings.cubeAreas != null) {
             for (CustomGeneratorSettings.IntAABB aabb : settings.cubeAreas.keySet()) {
-                this.areaGenerators.put(aabb, new CustomTerrainGenerator(world, settings.cubeAreas.get(aabb), seed, false));
+                this.areaGenerators.put(aabb, new CustomTerrainGenerator(world, CustomCubicWorldType.makeBiomeProvider(world, settings), settings.cubeAreas.get(aabb), seed, false));
             }
         }
     }


### PR DESCRIPTION
…vider

Accessing generator from parallel thread sometimes cause exception in BiomeCache:
```
java.lang.ArrayIndexOutOfBoundsException: -1
	at it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap.rehash(Long2ObjectOpenHashMap.java:998)
	at it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap.removeEntry(Long2ObjectOpenHashMap.java:280)
	at it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap.remove(Long2ObjectOpenHashMap.java:389)
	at net.minecraft.world.biome.BiomeCache.func_76838_a(SourceFile:73)
	at net.minecraft.world.biome.BiomeProvider.func_76938_b(BiomeProvider.java:209)
	at net.minecraft.world.WorldServer.func_72835_b(WorldServer.java:186)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:756)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668)
	at net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:185)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
	at java.lang.Thread.run(Thread.java:745)
```

I would like to try to workaround that by creating separated instance of `CustomTerrainGenerator` for a parallel thread.