### PR TITLE
Make generation synchronious

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/CustomTerrainGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/CustomTerrainGenerator.java
@@ -180,7 +180,7 @@ public class CustomTerrainGenerator extends BasicCubeGenerator {
                 .cached(CACHE_SIZE_3D, HASH_3D);
     }
 
-    @Override public CubePrimer generateCube(int cubeX, int cubeY, int cubeZ) {
+    @Override synchronized public CubePrimer generateCube(int cubeX, int cubeY, int cubeZ) {
         if (!areaGenerators.isEmpty()) {
             for (CustomGeneratorSettings.IntAABB aabb : areaGenerators.keySet()) {
                 if (!aabb.contains(cubeX, cubeY, cubeZ)) {


### PR DESCRIPTION
I spend a few minutes flying around and everything seems to be OK with this simple change.
Making chunk seed field ThreadLocal making worldgen horrible slow. Making second instance of cube generator occupies a hella lot of memory. I think this solution is a best.