### PR TITLE
Make CustomTerrainGenerator generateStructures protected

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/CustomTerrainGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/CustomTerrainGenerator.java
@@ -332,7 +332,7 @@ public class CustomTerrainGenerator extends BasicCubeGenerator {
         return block;
     }
 
-    private void generateStructures(CubePrimer cube, CubePos cubePos) {
+    protected void generateStructures(CubePrimer cube, CubePos cubePos) {
         // generate world populator
         if (this.conf.caves) {
             this.caveGenerator.generate(world, cube, cubePos);


### PR DESCRIPTION
In my fork of Hybrid generator I want to use it, and to avoid reflection the best thing is to apply this change upstream