### PR TITLE
Add Getters to CustomTerrainGenerator & Baseclass for Cave and Ravine Generator

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/CustomTerrainGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/CustomTerrainGenerator.java
@@ -332,7 +332,7 @@ public class CustomTerrainGenerator extends BasicCubeGenerator {
         return block;
     }
 
-    protected void generateStructures(CubePrimer cube, CubePos cubePos) {
+    public void generateStructures(CubePrimer cube, CubePos cubePos) {
         // generate world populator
         if (this.conf.caves) {
             this.caveGenerator.generate(world, cube, cubePos);
@@ -343,5 +343,25 @@ public class CustomTerrainGenerator extends BasicCubeGenerator {
         if (this.conf.strongholds) {
             this.strongholds.generate(world, cube, cubePos);
         }
+    }
+
+    public final ICubicStructureGenerator getCaveGenerator() {
+        return caveGenerator;
+    }
+
+    public final ICubicFeatureGenerator getStrongholds() {
+        return strongholds;
+    }
+
+    public final ICubicStructureGenerator getRavineGenerator() {
+        return ravineGenerator;
+    }
+
+    public CustomGeneratorSettings getConfig() {
+        return conf;
+    }
+
+    public Map<Biome, ICubicPopulator> getPopulators() {
+        return populators;
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CaveCommonBaseStructureGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CaveCommonBaseStructureGenerator.java
@@ -1,3 +1,26 @@
+/*
+ *  This file is part of Cubic World Generation, licensed under the MIT License (MIT).
+ *
+ *  Copyright (c) 2015-2020 contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
 package io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.structure;
 
 import io.github.opencubicchunks.cubicchunks.api.util.CubePos;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CaveCommonBaseStructureGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CaveCommonBaseStructureGenerator.java
@@ -1,0 +1,22 @@
+package io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.structure;
+
+import io.github.opencubicchunks.cubicchunks.api.util.CubePos;
+import io.github.opencubicchunks.cubicchunks.api.worldgen.CubePrimer;
+import io.github.opencubicchunks.cubicchunks.api.worldgen.structure.ICubicStructureGenerator;
+import net.minecraft.world.World;
+
+import java.util.Random;
+
+public abstract class CaveCommonBaseStructureGenerator implements ICubicStructureGenerator {
+
+    public static final int RANGE = 8;
+
+    @Override
+    public void generate(World world, CubePrimer cube, CubePos cubePos) {
+        this.generate(world, cube, cubePos, this::generate, RANGE, RANGE, 1, 1);
+    }
+
+    protected abstract void generate(World world, Random rand, CubePrimer cube, int structureX, int structureY, int structureZ,
+                            CubePos generatedCubePos);
+
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CubicCaveGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CubicCaveGenerator.java
@@ -34,7 +34,6 @@ import static net.minecraft.util.math.MathHelper.sin;
 import io.github.opencubicchunks.cubicchunks.api.worldgen.CubePrimer;
 import io.github.opencubicchunks.cubicchunks.api.util.CubePos;
 import io.github.opencubicchunks.cubicchunks.api.world.ICube;
-import io.github.opencubicchunks.cubicchunks.api.worldgen.structure.ICubicStructureGenerator;
 import io.github.opencubicchunks.cubicchunks.cubicgen.StructureGenUtil;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.block.state.IBlockState;
@@ -54,7 +53,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 //TODO: Fix code duplication beterrn cave and cave generators
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class CubicCaveGenerator implements ICubicStructureGenerator {
+public class CubicCaveGenerator extends CaveCommonBaseStructureGenerator {
 
     //=============================================
     //Possibly configurable values
@@ -147,17 +146,11 @@ public class CubicCaveGenerator implements ICubicStructureGenerator {
      */
     private static final double CAVE_FLOOR_DEPTH = -0.7;
 
-    private static final int RANGE = 8;
-
     /**
      * Controls which blocks can be replaced by cave
      */
     private static final Predicate<IBlockState> isBlockReplaceable = (state ->
             state.getBlock() == Blocks.STONE || state.getBlock() == Blocks.DIRT || state.getBlock() == Blocks.GRASS);
-
-    @Override public void generate(World world, CubePrimer cube, CubePos cubePos) {
-        this.generate(world, cube, cubePos, this::generate, RANGE, RANGE, 1, 1);
-    }
 
     protected void generate(World world, Random rand, CubePrimer cube,
             int cubeXOrigin, int cubeYOrigin, int cubeZOrigin, CubePos generatedCubePos) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CubicCaveGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CubicCaveGenerator.java
@@ -53,7 +53,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 //TODO: Fix code duplication beterrn cave and cave generators
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class CubicCaveGenerator extends CaveCommonBaseStructureGenerator {
+public class CubicCaveGenerator implements IFlexHandlerStructureGenerator {
 
     //=============================================
     //Possibly configurable values
@@ -152,8 +152,13 @@ public class CubicCaveGenerator extends CaveCommonBaseStructureGenerator {
     private static final Predicate<IBlockState> isBlockReplaceable = (state ->
             state.getBlock() == Blocks.STONE || state.getBlock() == Blocks.DIRT || state.getBlock() == Blocks.GRASS);
 
+    @Override
+    public Handler getHandler() {
+        return this::generate;
+    }
+
     protected void generate(World world, Random rand, CubePrimer cube,
-            int cubeXOrigin, int cubeYOrigin, int cubeZOrigin, CubePos generatedCubePos) {
+                            int cubeXOrigin, int cubeYOrigin, int cubeZOrigin, CubePos generatedCubePos) {
         if (rand.nextInt(CAVE_RARITY) != 0) {
             return;
         }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CubicRavineGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CubicRavineGenerator.java
@@ -33,6 +33,7 @@ import io.github.opencubicchunks.cubicchunks.api.util.Coords;
 import io.github.opencubicchunks.cubicchunks.api.worldgen.CubePrimer;
 import io.github.opencubicchunks.cubicchunks.api.util.CubePos;
 import io.github.opencubicchunks.cubicchunks.api.world.ICube;
+import io.github.opencubicchunks.cubicchunks.api.worldgen.structure.ICubicStructureGenerator;
 import io.github.opencubicchunks.cubicchunks.cubicgen.StructureGenUtil;
 import io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.CustomGeneratorSettings;
 import mcp.MethodsReturnNonnullByDefault;
@@ -49,7 +50,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class CubicRavineGenerator extends CaveCommonBaseStructureGenerator {
+public class CubicRavineGenerator implements IFlexHandlerStructureGenerator {
 
     /**
      * Vanilla value: 50
@@ -142,6 +143,11 @@ public class CubicRavineGenerator extends CaveCommonBaseStructureGenerator {
         this.maxCubeY = Coords.blockToCube(cfg.expectedBaseHeight);
     }
 
+    @Override
+    public ICubicStructureGenerator.Handler getHandler() {
+        return this::generate;
+    }
+
     protected void generate(World world, Random rand, CubePrimer cube, int structureX, int structureY, int structureZ,
             CubePos generatedCubePos) {
         if (rand.nextInt(RAVINE_RARITY) != 0 || structureY > maxCubeY) {
@@ -179,7 +185,7 @@ public class CubicRavineGenerator extends CaveCommonBaseStructureGenerator {
         float vertDirChange = 0.0F;
 
         if (maxWalkedDistance <= 0) {
-            int maxBlockRadius = cubeToMinBlock(RANGE - 1);
+            int maxBlockRadius = cubeToMinBlock(IFlexHandlerStructureGenerator.RANGE - 1);
             maxWalkedDistance = maxBlockRadius - rand.nextInt(maxBlockRadius / 4);
         }
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CubicRavineGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/CubicRavineGenerator.java
@@ -33,7 +33,6 @@ import io.github.opencubicchunks.cubicchunks.api.util.Coords;
 import io.github.opencubicchunks.cubicchunks.api.worldgen.CubePrimer;
 import io.github.opencubicchunks.cubicchunks.api.util.CubePos;
 import io.github.opencubicchunks.cubicchunks.api.world.ICube;
-import io.github.opencubicchunks.cubicchunks.api.worldgen.structure.ICubicStructureGenerator;
 import io.github.opencubicchunks.cubicchunks.cubicgen.StructureGenUtil;
 import io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.CustomGeneratorSettings;
 import mcp.MethodsReturnNonnullByDefault;
@@ -50,7 +49,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class CubicRavineGenerator implements ICubicStructureGenerator {
+public class CubicRavineGenerator extends CaveCommonBaseStructureGenerator {
 
     /**
      * Vanilla value: 50
@@ -139,15 +138,8 @@ public class CubicRavineGenerator implements ICubicStructureGenerator {
      */
     @Nonnull private float[] widthDecreaseFactors = new float[1024];
 
-    private final int range = 8;
-
     public CubicRavineGenerator(CustomGeneratorSettings cfg) {
         this.maxCubeY = Coords.blockToCube(cfg.expectedBaseHeight);
-    }
-
-
-    @Override public void generate(World world, CubePrimer cube, CubePos cubePos) {
-        this.generate(world, cube, cubePos, this::generate, range, range, 1, 1);
     }
 
     protected void generate(World world, Random rand, CubePrimer cube, int structureX, int structureY, int structureZ,
@@ -187,7 +179,7 @@ public class CubicRavineGenerator implements ICubicStructureGenerator {
         float vertDirChange = 0.0F;
 
         if (maxWalkedDistance <= 0) {
-            int maxBlockRadius = cubeToMinBlock(this.range - 1);
+            int maxBlockRadius = cubeToMinBlock(RANGE - 1);
             maxWalkedDistance = maxBlockRadius - rand.nextInt(maxBlockRadius / 4);
         }
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/IFlexHandlerStructureGenerator.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/cubicgen/customcubic/structure/IFlexHandlerStructureGenerator.java
@@ -30,16 +30,16 @@ import net.minecraft.world.World;
 
 import java.util.Random;
 
-public abstract class CaveCommonBaseStructureGenerator implements ICubicStructureGenerator {
+public interface IFlexHandlerStructureGenerator extends ICubicStructureGenerator {
 
-    public static final int RANGE = 8;
+    int RANGE = 8;
 
     @Override
-    public void generate(World world, CubePrimer cube, CubePos cubePos) {
-        this.generate(world, cube, cubePos, this::generate, RANGE, RANGE, 1, 1);
+    default void generate(World world, CubePrimer cube, CubePos cubePos) {
+        this.generate(world, cube, cubePos, getHandler(), RANGE, RANGE, 1, 1);
     }
 
-    protected abstract void generate(World world, Random rand, CubePrimer cube, int structureX, int structureY, int structureZ,
-                            CubePos generatedCubePos);
+    ICubicStructureGenerator.Handler getHandler();
+
 
 }


### PR DESCRIPTION
I am sorry my previous PR was a bit premature.

This PR adds 5 getters to CustomTerrainGenerator that allow HybridTerrainGenerator to access the populators and generators directly if it needs to. 

Also it creates a baseclass for CubicCaveGenerator & CubicRavineGenerator. Which allows reasoning about both of them more detailed. This will be used to smooth the hard transition between Vanilla and CubicChunk Generators caves